### PR TITLE
forced to use opencv3_catkin instead of ros/system opencv

### DIFF
--- a/cv_bridge/package.xml
+++ b/cv_bridge/package.xml
@@ -20,13 +20,13 @@
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>boost</build_depend>
-  <build_depend>opencv3</build_depend>
+  <build_depend>opencv3_catkin</build_depend>
   <build_depend>python</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <exec_depend>boost</exec_depend>
-  <exec_depend>opencv3</exec_depend>
+  <exec_depend>opencv3_catkin</exec_depend>
   <exec_depend>python</exec_depend>
   <exec_depend>rosconsole</exec_depend>
   <build_export_depend>sensor_msgs</build_export_depend>

--- a/image_geometry/package.xml
+++ b/image_geometry/package.xml
@@ -18,10 +18,10 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend>opencv3</build_depend>
+  <build_depend>opencv3_catkin</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
-  <exec_depend>opencv3</exec_depend>
+  <exec_depend>opencv3_catkin</exec_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
 
   <doc_depend>dvipng</doc_depend>


### PR DESCRIPTION
With this changes, it should be possible to use OpenCV3 with Ros Indigo. See https://github.com/ethz-asl/multiagent_mapping/pull/3302#issuecomment-261557828

@dymczykm @mfehr @ffurrer 