### PR TITLE
use opencv3_catkin explicitly

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
   set(CMAKE_CXX_STANDARD 11)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS rosconsole sensor_msgs)
+find_package(catkin REQUIRED COMPONENTS rosconsole sensor_msgs opencv3_catkin)
 
 if(NOT ANDROID)
   find_package(PythonLibs)
@@ -19,25 +19,17 @@ if(NOT ANDROID)
 else()
 find_package(Boost REQUIRED)
 endif()
-find_package(OpenCV 3 REQUIRED
-  COMPONENTS
-    opencv_core
-    opencv_imgproc
-    opencv_imgcodecs
-  CONFIG
-)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS rosconsole sensor_msgs
-  DEPENDS OpenCV
+  CATKIN_DEPENDS rosconsole sensor_msgs opencv3_catkin
   CFG_EXTRAS cv_bridge-extras.cmake
 )
 
 catkin_python_setup()
 
-include_directories(include ${Boost_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 if(NOT ANDROID)
 add_subdirectory(python)

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -32,11 +32,7 @@ if (PYTHON_VERSION_MAJOR VERSION_EQUAL 3)
   add_definitions(-DPYTHON3)
 endif()
 
-if (OpenCV_VERSION_MAJOR VERSION_EQUAL 3)
 add_library(${PROJECT_NAME}_boost module.cpp module_opencv3.cpp)
-else()
-add_library(${PROJECT_NAME}_boost module.cpp module_opencv2.cpp)
-endif()
 target_link_libraries(${PROJECT_NAME}_boost ${Boost_LIBRARIES}
                                             ${catkin_LIBRARIES}
                                             ${PYTHON_LIBRARIES}


### PR DESCRIPTION
When I install cv_bridge to install space, generated cmake file depends on devel space:

```
$ cat install/share/cv_bridge/cmake/cv_bridgeConfig.cmake
...
set(libraries "cv_bridge;/home/junya/maplab_ws/devel/lib/libopencv_core.so.3.2.0;/home/junya/maplab_ws/devel/lib/libopencv_imgproc.so.3.2.0;/home/junya/maplab_ws/devel/lib/libopencv_imgcodecs.so.3.2.0")
...
```

This is because opencv3_catkin is not used as catkin package.

In this pull request, I resolved the problem by fixing the configuration to use opencv3_catkin explicitly.